### PR TITLE
self class in mapper

### DIFF
--- a/lib/hash_map/base.rb
+++ b/lib/hash_map/base.rb
@@ -8,7 +8,7 @@ module HashMap
     end
 
     def mapper
-      @mapper ||= Mapper.new(original, self.class.attributes)
+      @mapper ||= Mapper.new(original, self)
     end
 
     def output

--- a/lib/hash_map/mapper.rb
+++ b/lib/hash_map/mapper.rb
@@ -1,14 +1,14 @@
 module HashMap
   class Mapper
-    attr_reader :original, :data_structure
-    def initialize(original, data_structure)
+    attr_reader :original, :hash_map
+    def initialize(original, hash_map)
       @original = HashWithIndifferentAccess.new(original)
-      @data_structure = data_structure
+      @hash_map = hash_map
     end
 
     def output
       new_hash = HashWithIndifferentAccess.new
-      data_structure.each do |struc|
+      hash_map.class.attributes.each do |struc|
         value = get_value(struc)
         new_hash.deep_merge! build_keys(struc[:key], value)
       end
@@ -37,9 +37,9 @@ module HashMap
       block = struct[:proc]
       if struct[:from_child]
         nested = get_value_from_key(struct, :from_child)
-        block.call(nested, original)
+        hash_map.instance_exec nested, original, &block
       else
-        block.call(original, original)
+        hash_map.instance_exec original, original, &block
       end
     end
 

--- a/lib/hash_map/version.rb
+++ b/lib/hash_map/version.rb
@@ -1,3 +1,3 @@
 module HashMap
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/examples/blocks_spec.rb
+++ b/spec/examples/blocks_spec.rb
@@ -3,6 +3,7 @@ require 'pry'
 describe 'Blocks' do
   describe 'inside from_child' do
     class Blocks < HashMap::Base
+
       from_child :address do
         property :street do |address|
           address[:street].upcase
@@ -18,6 +19,9 @@ describe 'Blocks' do
       end
       property :name do |original|
         original[:name]
+      end
+      property :class_name do
+        self.class.name
       end
     end
 
@@ -37,5 +41,6 @@ describe 'Blocks' do
     it { expect(subject[:owner]).to eq 'name' }
     it { expect(subject[:street]).to eq 'STREET' }
     it { expect(subject[:country]).to eq 'ES' }
+    it { expect(subject[:class_name]).to eq 'Blocks' }
   end
 end

--- a/spec/hash_map/mapper_spec.rb
+++ b/spec/hash_map/mapper_spec.rb
@@ -17,17 +17,21 @@ module HashMap
         phone: nil
       }
     end
-    let(:data_structure) do
-      [
-        { key: [:first_name], from: [:name] },
-        { key: [:last_name], proc: proc { |input| "#{input[:first_surname]} #{input[:second_surname]}" } },
-        { key: [:language], from: [:address, :country, :language], transform: proc {|context, value| value.downcase } },
-        { key: [:email, :address], from: [:email] },
-        { key: [:email, :type], default: :work },
-      ]
+
+    class HashMap
+      def self.attributes
+        [
+          { key: [:first_name], from: [:name] },
+          { key: [:last_name], proc: proc { |input| "#{input[:first_surname]} #{input[:second_surname]}" } },
+          { key: [:language], from: [:address, :country, :language], transform: proc {|context, value| value.downcase } },
+          { key: [:email, :address], from: [:email] },
+          { key: [:email, :type], default: :work },
+        ]
+      end
     end
+
     subject do
-      described_class.new(original, data_structure).output
+      described_class.new(original, HashMap.new).output
     end
 
     it { expect(subject[:first_name]).to eq original[:name] }

--- a/spec/hash_map/mapper_spec.rb
+++ b/spec/hash_map/mapper_spec.rb
@@ -18,7 +18,7 @@ module HashMap
       }
     end
 
-    class HashMap
+    class FooHashMap
       def self.attributes
         [
           { key: [:first_name], from: [:name] },
@@ -31,7 +31,7 @@ module HashMap
     end
 
     subject do
-      described_class.new(original, HashMap.new).output
+      described_class.new(original, FooHashMap.new).output
     end
 
     it { expect(subject[:first_name]).to eq original[:name] }


### PR DESCRIPTION
When executing this code:

```ruby
class Blocks < HashMap::Base
   from_child :address do
      property :street do |address|
         self.class.name
      end
   end
end
```

`self.class.name` was returning `HashMap::DSL` instead of `Blocks`

From now, it will execute the block using `instance_exec`.  Therefore `self` will always return the class in which the block is used.